### PR TITLE
fix all shift-reduce conflicts

### DIFF
--- a/interpreter/interpreter.py
+++ b/interpreter/interpreter.py
@@ -215,6 +215,9 @@ def interpret(ast):
             
             case 'return-statement':
                 return ( 'RETURN', interpret_internal(ast[1], assignment_store) )
+
+            case 'empty':
+                return 
             
             case _:
                 raise(ValueError(f'Illegal AST Node {ast[0]}'))

--- a/parser/parser.py
+++ b/parser/parser.py
@@ -93,8 +93,10 @@ t_ignore = ' \t'
 lexer = lex.lex(reflags=re.UNICODE|re.VERBOSE)
 
 precedence = (
+    ('left', 'DICT_PAIR_SEPARATOR'),
+    ('left', 'LIST_ITEM_SEPARATOR'),
     ('nonassoc', 'LT', 'GT', 'EQ'),  # Nonassociative operators
-    ('left', 'PLUS', 'MINUS'),
+    ('left', 'PLUS', 'MINUS', 'MOD'),
     ('left', 'TIMES', 'DIVIDE'),
     ('nonassoc', 'COMMA'),
     ('nonassoc', 'IN_DICT', 'IN_LIST'),
@@ -173,15 +175,19 @@ def p_expression_variable(p):
     p[0] = ('variable-expression',p[1])
 
 def p_statement_recursive(p):
-    'statement : statement statement'
+    'statements : statement statements'
     p[0] = ('recursive-statement', p[1], p[2])
+
+def p_statement_base(p):
+    'statements : empty'
+    p[0] = ('empty', )
 
 def p_statement_expression(p):
     'statement : expression END_OF_STATEMENT'
     p[0] = ('expression-statement', p[1])
 
 def p_statement_if(p):
-    'statement : IF expression THEN statement ELSE THEN statement END_OF_IF_THEN_ELSE END_OF_STATEMENT'
+    'statement : IF expression THEN statements ELSE THEN statements END_OF_IF_THEN_ELSE END_OF_STATEMENT'
     p[0] = ('if-statement', p[2], p[4], p[7])
 
 def p_parameters_recursive(p):
@@ -192,23 +198,23 @@ def p_parameters_base(p):
     '''parameters : NAME'''
     p[0] = ('parameters', p[1])
 
-# def p_empty(p):
-#     'empty :'
-#     p[0] = None
+def p_empty(p):
+    'empty :'
+    p[0] = None
 
 '''
 ----------------- functions start ----------------- 
 '''
 def p_function_expression(p):
-    'expression : FUNCTION WITH_PARAMS parameters START_OF_FUNCTION statement END_OF_FUNCTION'
+    'expression : FUNCTION WITH_PARAMS parameters START_OF_FUNCTION statements END_OF_FUNCTION'
     p[0] = ('function-expression', p[3], p[5])
 
 def p_function_expression_no_params(p):
-    'expression : FUNCTION START_OF_FUNCTION statement END_OF_FUNCTION'
+    'expression : FUNCTION START_OF_FUNCTION statements END_OF_FUNCTION'
     p[0] = ('function-expression', p[3])
 
 def p_function_application(p):
-    'expression : RUN NAME WITH list-body'
+    'expression : RUN NAME WITH list-body END_OF_LIST'
     p[0] = ('function-application-expression', p[2], p[4])
 
 def p_function_application_no_args(p):
@@ -216,7 +222,7 @@ def p_function_application_no_args(p):
     p[0] = ('function-application-expression', p[2])
 
 def p_import_function_application(p):
-    'expression : RUN NAME IMPORT_FUNCTION_SEPARATOR NAME WITH list-body'
+    'expression : RUN NAME IMPORT_FUNCTION_SEPARATOR NAME WITH list-body END_OF_LIST'
     p[0] = ('function-import-application-expression', p[2], p[4], p[6])
     
 def p_import_function_application_no_args(p):
@@ -239,44 +245,44 @@ def p_statement_break(p):
     p[0] = ('break-statement',)
 
 def p_statement_while(p):
-    'statement : WHILE expression DO statement END_OF_WHILE END_OF_STATEMENT'
+    'statement : WHILE expression DO statements END_OF_WHILE END_OF_STATEMENT'
     p[0] = ('while-statement', p[2], p[4])
     
 def p_expression_print(p):
-    'expression : PRINT expression'
+    'statement : PRINT expression END_OF_STATEMENT'
     p[0] = ('print-function', p[2])
 
 def p_expression_push(p):
-    'expression : PUSH expression IN_LIST expression'
+    'expression : PUSH expression IN_LIST expression END_OF_LIST'
     p[0] = ('push-function', p[2], p[4])
 
 def p_expression_pop(p):
-    'expression : POP expression'
+    'expression : POP expression END_OF_LIST'
     p[0] = ('pop-function', p[2])
 
 def p_expression_array_index(p):
-    'expression : ARRAY_INDEX expression IN_LIST expression'
+    'expression : ARRAY_INDEX expression IN_LIST expression END_OF_LIST'
     p[0] = ('index-expression', p[2], p[4])
     
 def p_expression_dict_lookup(p):
-    'expression : DICT_LOOKUP expression IN_DICT expression'
+    'expression : DICT_LOOKUP expression IN_DICT expression END_OF_LIST'
     p[0] = ('lookup-expression', p[2], p[4])
 
 def p_expression_dict_add(p):
-    'expression : PUSH expression DICT_PAIR_SEPARATOR expression IN_DICT expression'
+    'expression : PUSH expression DICT_PAIR_SEPARATOR expression IN_DICT expression END_OF_LIST'
     p[0] = ('add-expression', p[2], p[4], p[6])
 
 def p_expression_dict_remove(p):
-    'expression : DICT_REMOVE expression IN_DICT expression'
+    'expression : DICT_REMOVE expression IN_DICT expression END_OF_LIST'
     p[0] = ('remove-expression', p[2], p[4])
     
 def p_expression_length(p):
-    'expression : LENGTH expression'
+    'expression : LENGTH expression END_OF_LIST'
     p[0] = ('length-function', p[2])
     
 # Import python's built-in functions
 def p_statement_import(p):
-    'expression : IMPORT STRING AS NAME END_OF_IMPORT'
+    'statement : IMPORT STRING AS NAME END_OF_IMPORT END_OF_STATEMENT'
     p[0] = ('import-statement', p[2], p[4])
 
 def p_statement_pass(p):
@@ -291,7 +297,7 @@ def p_error(p):
         
 # Error rule for syntax errors
 # Build the parser
-parser = yacc.yacc(start='statement', debug=True)
+parser = yacc.yacc(start='statements', debug=True)
     # pprint.pprint(out)
 
 def parse(script):

--- a/tests/test_data/test_files/dict_operations_test.haellae
+++ b/tests/test_data/test_files/dict_operations_test.haellae
@@ -7,11 +7,11 @@ x ære-samma-som e-orlbok-beståænes-av
 
 spøtt-ut x.
 
-spøtt-ut slå-opp "1" i-orlboka x.
-spøtt-ut hællæ slå-opp "2" i-orlboka x plussær slå-opp "3" i-orlboka x prekæs.
+spøtt-ut slå-opp "1" i-orlboka x å-det-var-det.
+spøtt-ut hællæ slå-opp "2" i-orlboka x å-det-var-det plussær slå-opp "3" i-orlboka x å-det-var-det prekæs.
 
-fjærn "4" i-orlboka x.
+fjærn "4" i-orlboka x å-det-var-det.
 spøtt-ut x.
 
-legg-te "4" betyænes "This is now a string wowzers" i-orlboka x.
+legg-te "4" betyænes "This is now a string wowzers" i-orlboka x å-det-var-det.
 spøtt-ut x.

--- a/tests/test_data/test_files/function_application_test.haellae
+++ b/tests/test_data/test_files/function_application_test.haellae
@@ -7,4 +7,4 @@ f ære-samma-som en-fungsjon såm-brukær a å b såm-gjør
 
 x ære-samma-som 8.
 
-kjør f med 1 å 2.
+kjør f med 1 å 2 å-det-var-det.

--- a/tests/test_data/test_files/function_return_test.haellae
+++ b/tests/test_data/test_files/function_return_test.haellae
@@ -11,5 +11,5 @@ is_prime ære-samma-som en-fungsjon såm-brukær n såm-gjør
     gi-tilbake "Prime".
 åså-varn-færi.
 
-x ære-samma-som kjør is_prime med 101.
+x ære-samma-som kjør is_prime med 101 å-det-var-det.
 spøtt-ut x.

--- a/tests/test_data/test_files/import_test.haellae
+++ b/tests/test_data/test_files/import_test.haellae
@@ -1,3 +1,3 @@
 hent-ut-pytonslange-funksjon "math" å-kallen-for matte i-samma-slengen.
 
-spøtt-ut kjør matte dått fmod med 10 å 3.
+spøtt-ut kjør matte dått fmod med 10 å 3 å-det-var-det.

--- a/tests/test_data/test_files/list_operations_test.haellae
+++ b/tests/test_data/test_files/list_operations_test.haellae
@@ -1,7 +1,7 @@
 x ære-samma-som en-bråtæ-beståænes-av 1 å 2 å en-bråtæ-beståænes-av 3 å 4 å-det-var-det å-det-var-det.
-legg-te hællæ 3 plussær 2 prekæs i-bråtæn x.
+legg-te hællæ 3 plussær 2 prekæs i-bråtæn x å-det-var-det.
 spøtt-ut x.
-y ære-samma-som græbb-fra x.
+y ære-samma-som græbb-fra x å-det-var-det.
 spøtt-ut y.
 spøtt-ut x.
-spøtt-ut plass-nummer hællæ 1 gangær 1 prekæs i-bråtæn x.
+spøtt-ut plass-nummer hællæ 1 gangær 1 prekæs i-bråtæn x å-det-var-det.


### PR DESCRIPTION
The main cause of the conflicts was ambiguity in the breakdown of the program into statements. I fixed this by changing the statement structure slightly.
Defined precedence for Mod
Function args and params must be ended with a keyword

